### PR TITLE
Nice command line interface; allow scaling and translating of glyphs

### DIFF
--- a/icons2font.py
+++ b/icons2font.py
@@ -1,7 +1,16 @@
-import sys
-import os
-from xml.dom import minidom
+#!/usr/bin/env python2.7
+
+import argparse
+import logging
 import md5
+import os
+import sys
+
+from xml.dom import minidom
+
+import fontforge
+
+log = logging.getLogger(__name__)
 
 DESIGNER_FONT_START_CHAR = "A"
 GSIZE = 1400
@@ -343,9 +352,8 @@ def do_glyph(data, glyphname, svg):
 
     #svg.write(GLYPH.format(glyphname, path))
 
-def gen_svg_font(glyph_files, output_dir, font_name, glyph_name):
-
-    svg = open(output_dir + font_name + ".svg",'w')
+def gen_svg_font(glyph_files, output_path, font_name, glyph_name):
+    svg = open(output_path, 'w')
     svg.write(HEADER.format(font_name))
 
     # use the special unicode user area for char encoding
@@ -361,21 +369,25 @@ def gen_svg_font(glyph_files, output_dir, font_name, glyph_name):
     svg.flush()
     svg.close()
 
+    log.info("Generated {}".format(output_path))
 
-def gen_css_for_font(glyph_files, output_dir, font_name, hash):
-    css = open(output_dir + font_name + ".scss",'w')
-    css.write(CSS_HEADER.format(font_name, hash))
+
+def gen_scss_for_font(glyph_files, output_path, font_name, hash):
+    scss = open(output_path,'w')
+    scss.write(CSS_HEADER.format(font_name, hash))
 
     for index, f in enumerate(glyph_files):
         glyph_name = font_name + "-" + f.split("/")[-1].replace(".svg", "")
-        css.write(
+        scss.write(
             '.{0}:before {{\n    content: "\{1:04x}";\n}}\n'.format(
                 glyph_name,
                 USER_AREA + index))
 
+    log.info("Generated {}".format(output_path))
 
-def gen_html_for_font(glyph_files, output_dir, font_name):
-    doc = open(output_dir + font_name + ".html",'w')
+
+def gen_html_for_font(glyph_files, output_path, font_name):
+    doc = open(output_path,'w')
     doc.write(DOC_HEADER.format(font_name))
 
     for index, f in enumerate(glyph_files):
@@ -386,74 +398,137 @@ def gen_html_for_font(glyph_files, output_dir, font_name):
 
     doc.write(DOC_FOOTER.format(font_name))
 
+    log.info("Generated {}".format(output_path))
 
-def main():
-    input_dir = sys.argv[1]
-    output_dir = sys.argv[2]
-    font_name = "icon"
-    if len(sys.argv) > 3:
-        font_name = sys.argv[3]
 
-    if not output_dir.endswith("/"):
-        output_dir = output_dir + "/"
+def parse_args():
+    parser = argparse.ArgumentParser(
+        description='Convert a folder of SVG files into several font formats')
+    parser.add_argument(
+        "input_dir", action="store", help="Path to a folder of SVG files")
+    parser.add_argument(
+        "output_dir", action="store", help="Path to a folder to put output files in")
+    parser.add_argument(
+        "font_name", default="icon", action="store", help="Output file name *and* font name. Defaults to 'icon'.")
 
-    # make sure output dir exists
-    try:
-       os.makedirs(output_dir)
-    except:
-       pass
+    parser.add_argument('-v', '--verbose', action='count', help="Add one for info logging, add another for debug logging")
 
+    parser.add_argument('--designer', action='store_true', default=True, help='(default) Generate "designer" variant (uses ASCII range instead of user extension range)')
+    parser.add_argument('--no-designer', action='store_false', dest='designer', help="Don't generate \"designer\" variant")
+
+    parser.add_argument('--ignore', action='append', default=[], help="Ignore a glyph. Do not include the .svg extension. May pass more than once.")
+
+    formats_group = parser.add_argument_group('Formats', 'Enable and disable individual formats. All are enabled by default.')
+
+    for fmt in ('scss', 'html', 'woff', 'otf', 'eot'):
+        formats_group.add_argument('--' + fmt, action='store_true', default=True, help='Generate {} files for fonts'.format(fmt.upper()))
+        formats_group.add_argument('--no-' + fmt, action='store_false', dest=fmt, help="Don't generate {} files for fonts".format(fmt.upper()))
+
+    return parser.parse_args()
+
+
+def configure_logging(level=0):
+    log_level = logging.WARNING
+    if level == 1:
+        log_level = logging.INFO
+    elif level > 1:
+        log_level = logging.DEBUG
+    logging.basicConfig(format='%(message)s', level=log_level)
+
+
+def get_glyph_file_paths(input_dir, ignore):
+    ignore = set(ignore)
     glyph_files = []
     for f in sorted(os.listdir(input_dir)):
         if not f.endswith(".svg"):
             continue
-        glyph_files.append(input_dir+"/"+f)
+        glyph_name = os.path.splitext(f)[0]
+        if glyph_name in ignore:
+            log.info("Ignoring glyph {}".format(glyph_name))
+            continue
+        path = os.path.join(input_dir, f)
+        glyph_files.append(path)
+        log.debug("Including file {}".format(path))
+    return glyph_files
+
+
+def main():
+    args = parse_args()
+    configure_logging(args.verbose)
+
+    input_dir = args.input_dir
+    output_dir = args.output_dir
+    font_name = args.font_name
+    designer_font_name = font_name + '-designer'
+
+    # make sure output dir exists
+    try:
+       os.makedirs(output_dir)
+    except OSError:
+       pass
+
+    glyph_files = get_glyph_file_paths(args.input_dir, args.ignore)
 
     # generate browser svg font
     gen_svg_font(
         glyph_files,
-        output_dir,
+        os.path.join(output_dir, font_name + '.svg'),
         font_name,
         glyph_name=lambda i:htmlhex(i + USER_AREA)
     )
 
-    # generate designer svg font
-    gen_svg_font(
-        glyph_files,
-        output_dir,
-        font_name+"-designer",
-        glyph_name=lambda i:htmlhex(i+ord(DESIGNER_FONT_START_CHAR))
-    )
+    if args.scss:
+        # get file hash
+        svg_font_hash = md5.new(open(os.path.join(output_dir, font_name+".svg")).read()).hexdigest()[:5]
 
-    # get file hash
-    hash = md5.new(open(output_dir+font_name+".svg").read()).hexdigest()[:5]
+        # generate scss
+        gen_scss_for_font(
+            glyph_files,
+            os.path.join(output_dir, font_name + ".scss"),
+            font_name,
+            svg_font_hash
+        )
 
-    # generate css
-    gen_css_for_font(
-        glyph_files,
-        output_dir,
-        font_name,
-        hash
-    )
-
-    # generate sample html
-    gen_html_for_font(
-        glyph_files,
-        output_dir,
-        font_name
-    )
+    if args.html:
+        # generate sample html
+        gen_html_for_font(
+            glyph_files,
+            os.path.join(output_dir, font_name + ".html"),
+            font_name
+        )
 
     # make ttf, woff, off, and eot browser fonts
-    import fontforge
-    font = fontforge.open(output_dir + font_name + ".svg")
-    font.generate(output_dir + font_name + ".ttf")
-    font.generate(output_dir + font_name + ".woff")
-    font.generate(output_dir + font_name + ".otf")
-    os.system("ttf2eot {0}.ttf > {0}.eot".format(output_dir + font_name))
+    font = fontforge.open(os.path.join(output_dir, font_name + ".svg"))
 
-    # make designer ttf
-    font = fontforge.open(output_dir + font_name + "-designer.svg")
-    font.generate(output_dir + font_name + "-designer.ttf")
+    ttf_path = os.path.join(output_dir, font_name + ".ttf")
+    font.generate(ttf_path)
+    log.info("Generated {}".format(ttf_path))
+
+    if args.woff:
+        path = os.path.join(output_dir, font_name + ".woff")
+        font.generate(path)
+        log.info("Generated {}".format(path))
+    if args.otf:
+        path = os.path.join(output_dir, font_name + ".otf")
+        font.generate(path)
+        log.info("Generated {}".format(path))
+    if args.eot:
+        eot_path = os.path.join(output_dir, font_name + '.eot')
+        os.system("ttf2eot {0} > {1}".format(ttf_path, eot_path))
+        log.info("Generated {}".format(eot_path))
+
+    if args.designer:
+        gen_svg_font(
+            glyph_files,
+            os.path.join(output_dir, designer_font_name + '.svg'),
+            font_name+"-designer",
+            glyph_name=lambda i:htmlhex(i+ord(DESIGNER_FONT_START_CHAR))
+        )
+
+        font = fontforge.open(os.path.join(output_dir, font_name + "-designer.svg"))
+        path = os.path.join(output_dir, font_name + "-designer.ttf")
+        font.generate(path)
+        log.info("Generated {}".format(path))
 
 
 if __name__ == "__main__":

--- a/icons2font.py
+++ b/icons2font.py
@@ -358,7 +358,7 @@ def do_glyph(data, glyphname, svg, scale=1.0, translate_y=0.0):
 def gen_svg_font(
         glyph_files, output_path, font_name, glyph_name,
         scale=1.0, translate_y=0.0,
-        scale_overrides={}, translate_y_overrides=0):
+        scale_overrides={}, translate_y_overrides={}):
     svg = open(output_path, 'w')
     svg.write(HEADER.format(font_name))
 
@@ -368,14 +368,17 @@ def gen_svg_font(
     for f in glyph_files:
         glyph_friendly_name = os.path.splitext(os.path.split(f)[1])[0]
         data = open(f).read()
+
         glyph_scale = scale
         if glyph_friendly_name in scale_overrides:
             glyph_scale = scale_overrides[glyph_friendly_name]
-            log.debug("Using scale override {}={}".format(glyph_friendly_name, glyph_scale))
-        glyph_translate_y = scale
+        log.debug("Using scale {}={}".format(glyph_friendly_name, glyph_scale))
+
+        glyph_translate_y = translate_y
         if glyph_friendly_name in translate_y_overrides:
             glyph_translate_y = translate_y_overrides[glyph_friendly_name]
-            log.debug("Using translate Y override {}={}".format(glyph_friendly_name, glyph_translate_y))
+        log.debug("Using translate Y {}={}".format(glyph_friendly_name, glyph_translate_y))
+
         do_glyph(data, glyph_name(index), svg, scale=glyph_scale, translate_y=glyph_translate_y)
 
         index += 1

--- a/icons2font.py
+++ b/icons2font.py
@@ -438,8 +438,12 @@ def parse_args():
     transforms_group.add_argument("--scale-all", default=1, action='store', type=float, help="Amount by which to scale all glyphs")
     transforms_group.add_argument("--translate-y-all", default=0, action='store', type=float, help="Amount by which to offset all glyphs on the Y axis. What are the units? That's for you to find out.")
 
-    transforms_group.add_argument("--scale-one", nargs=2, action='append', default=[], help="'--scale-one airplane 2' would scale the 'airplane' glyph 2x. Can be used more than once.")
-    transforms_group.add_argument("--translate-y-one", nargs=2, action='append', default=[], help="'--translate-y-one airplane 5' would move the 'airplane' glyph down 5 units. Can be used more than once.")
+    transforms_group.add_argument(
+        "--scale-one", nargs=2, action='append', default=[],
+        help="'--scale-one airplane 2' would scale the 'airplane' glyph 2x. Can be used more than once. This will _replace_ the global scale value for this glyph.")
+    transforms_group.add_argument(
+        "--translate-y-one", nargs=2, action='append', default=[],
+        help="'--translate-y-one airplane 5' would move the 'airplane' glyph down 5 units. Can be used more than once. This will _replace_ the global translate-y value for this glyph.")
 
     formats_group = parser.add_argument_group('Formats', 'Enable or disable individual formats. All are enabled by default.')
 

--- a/icons2font.py
+++ b/icons2font.py
@@ -423,6 +423,13 @@ def gen_html_for_font(glyph_files, output_path, font_name):
 
 
 def parse_args():
+    """
+    All of the boolean options have both an 'on' and an 'off' argument, which
+    defaults to 'on'. The only reason to have 'on' at all is so that you can
+    be very explicit about what you want, without worrying about whether the
+    defaults will change or whether you'll need to override it later.
+    """
+
     parser = argparse.ArgumentParser(
         description='Convert a folder of SVG files into several font formats')
     parser.add_argument(

--- a/icons2font.py
+++ b/icons2font.py
@@ -495,13 +495,11 @@ def main():
     log.info("Scale overrides: {}".format(scale_overrides))
     log.info("Translate Y overrides: {}".format(translate_y_overrides))
 
-    input_dir = args.input_dir
-    output_dir = args.output_dir
     designer_font_name = args.font_name + '-designer'
 
     # make sure output dir exists
     try:
-       os.makedirs(output_dir)
+       os.makedirs(args.output_dir)
     except OSError:
        pass
 
@@ -510,7 +508,7 @@ def main():
     # generate browser svg font
     gen_svg_font(
         glyph_files,
-        os.path.join(output_dir, args.font_name + '.svg'),
+        os.path.join(args.output_dir, args.font_name + '.svg'),
         args.font_name,
         glyph_name=lambda i:htmlhex(i + USER_AREA),
         scale=args.scale_all,
@@ -521,12 +519,12 @@ def main():
 
     if args.scss:
         # get file hash
-        svg_font_hash = md5.new(open(os.path.join(output_dir, args.font_name+".svg")).read()).hexdigest()[:5]
+        svg_font_hash = md5.new(open(os.path.join(args.output_dir, args.font_name+".svg")).read()).hexdigest()[:5]
 
         # generate scss
         gen_scss_for_font(
             glyph_files,
-            os.path.join(output_dir, args.font_name + ".scss"),
+            os.path.join(args.output_dir, args.font_name + ".scss"),
             args.font_name,
             svg_font_hash
         )
@@ -535,34 +533,34 @@ def main():
         # generate sample html
         gen_html_for_font(
             glyph_files,
-            os.path.join(output_dir, args.font_name + ".html"),
+            os.path.join(args.output_dir, args.font_name + ".html"),
             args.font_name
         )
 
     # make ttf, woff, off, and eot browser fonts
-    font = fontforge.open(os.path.join(output_dir, args.font_name + ".svg"))
+    font = fontforge.open(os.path.join(args.output_dir, args.font_name + ".svg"))
 
-    ttf_path = os.path.join(output_dir, args.font_name + ".ttf")
+    ttf_path = os.path.join(args.output_dir, args.font_name + ".ttf")
     font.generate(ttf_path)
     log.info("Generated {}".format(ttf_path))
 
     if args.woff:
-        path = os.path.join(output_dir, args.font_name + ".woff")
+        path = os.path.join(args.output_dir, args.font_name + ".woff")
         font.generate(path)
         log.info("Generated {}".format(path))
     if args.otf:
-        path = os.path.join(output_dir, args.font_name + ".otf")
+        path = os.path.join(args.output_dir, args.font_name + ".otf")
         font.generate(path)
         log.info("Generated {}".format(path))
     if args.eot:
-        eot_path = os.path.join(output_dir, args.font_name + '.eot')
+        eot_path = os.path.join(args.output_dir, args.font_name + '.eot')
         os.system("ttf2eot {0} > {1}".format(ttf_path, eot_path))
         log.info("Generated {}".format(eot_path))
 
     if args.designer:
         gen_svg_font(
             glyph_files,
-            os.path.join(output_dir, designer_font_name + '.svg'),
+            os.path.join(args.output_dir, designer_font_name + '.svg'),
             designer_font_name,
             glyph_name=lambda i:htmlhex(i+ord(DESIGNER_FONT_START_CHAR)),
             scale=args.scale_all,
@@ -571,8 +569,8 @@ def main():
             translate_y_overrides=translate_y_overrides
         )
 
-        font = fontforge.open(os.path.join(output_dir, designer_font_name + ".svg"))
-        path = os.path.join(output_dir, designer_font_name + ".ttf")
+        font = fontforge.open(os.path.join(args.output_dir, designer_font_name + ".svg"))
+        path = os.path.join(args.output_dir, designer_font_name + ".ttf")
         font.generate(path)
         log.info("Generated {}".format(path))
 

--- a/icons2font.py
+++ b/icons2font.py
@@ -439,10 +439,10 @@ def parse_args():
     transforms_group.add_argument("--translate-y-all", default=0, action='store', type=float, help="Amount by which to offset all glyphs on the Y axis. What are the units? That's for you to find out.")
 
     transforms_group.add_argument(
-        "--scale-one", nargs=2, action='append', default=[],
+        "--scale-one", nargs=2, metavar=('GLYPH_NAME', 'AMOUNT'), action='append', default=[],
         help="'--scale-one airplane 2' would scale the 'airplane' glyph 2x. Can be used more than once. This will _replace_ the global scale value for this glyph.")
     transforms_group.add_argument(
-        "--translate-y-one", nargs=2, action='append', default=[],
+        "--translate-y-one", nargs=2, metavar=('GLYPH_NAME', 'AMOUNT'), action='append', default=[],
         help="'--translate-y-one airplane 5' would move the 'airplane' glyph down 5 units. Can be used more than once. This will _replace_ the global translate-y value for this glyph.")
 
     formats_group = parser.add_argument_group('Formats', 'Enable or disable individual formats. All are enabled by default.')


### PR DESCRIPTION
These changes are intended to allow us to make a mobile-specific build of hipfont with whatever size and positioning tweaks we want, without affecting any other teams. It should not break any existing scripts.

Feature changes:
* Use argparse instead of `sys.argv` to parse args.
* Add copious options, mostly to disable things the mobile team doesn't need.
* Add logging.
* Add ways to scale and translate all glyphs and individual glyphs.
* Make `icons2font.py` executable.

Code changes:
* Use `os.path.join` instead of `+`
* Pass output path to functions instead of output directory
* All imports at top

Output of `./icons2font.py --help`:

```
usage: icons2font.py [-h] [-v] [--designer] [--no-designer] [--ignore IGNORE]
                     [--scale-all SCALE_ALL]
                     [--translate-y-all TRANSLATE_Y_ALL]
                     [--scale-one GLYPH_NAME AMOUNT]
                     [--translate-y-one GLYPH_NAME AMOUNT] [--scss]
                     [--no-scss] [--html] [--no-html] [--woff] [--no-woff]
                     [--otf] [--no-otf] [--eot] [--no-eot]
                     input_dir output_dir font_name

Convert a folder of SVG files into several font formats

positional arguments:
  input_dir             Path to a folder of SVG files
  output_dir            Path to a folder to put output files in
  font_name             Output file name *and* font name. Defaults to 'icon'.

optional arguments:
  -h, --help            show this help message and exit
  -v, --verbose         Add one for info logging, add another for debug
                        logging
  --designer            (default) Generate "designer" variant (uses ASCII
                        range instead of user extension range)
  --no-designer         Don't generate "designer" variant
  --ignore IGNORE       Ignore a glyph. Do not include the .svg extension. Can
                        be used more than once.

Transforms:
  Translate and scale glyphs

  --scale-all SCALE_ALL
                        Amount by which to scale all glyphs
  --translate-y-all TRANSLATE_Y_ALL
                        Amount by which to offset all glyphs on the Y axis.
                        What are the units? That's for you to find out.
  --scale-one GLYPH_NAME AMOUNT
                        '--scale-one airplane 2' would scale the 'airplane'
                        glyph 2x. Can be used more than once. This will
                        _replace_ the global scale value for this glyph.
  --translate-y-one GLYPH_NAME AMOUNT
                        '--translate-y-one airplane 5' would move the
                        'airplane' glyph down 5 units. Can be used more than
                        once. This will _replace_ the global translate-y value
                        for this glyph.

Formats:
  Enable or disable individual formats. All are enabled by default.

  --scss                Generate SCSS files for fonts
  --no-scss             Don't generate SCSS files for fonts
  --html                Generate HTML files for fonts
  --no-html             Don't generate HTML files for fonts
  --woff                Generate WOFF files for fonts
  --no-woff             Don't generate WOFF files for fonts
  --otf                 Generate OTF files for fonts
  --no-otf              Don't generate OTF files for fonts
  --eot                 Generate EOT files for fonts
  --no-eot              Don't generate EOT files for fonts
```